### PR TITLE
Allow double quotes on BNote content attribute

### DIFF
--- a/bn.py
+++ b/bn.py
@@ -287,7 +287,7 @@ class BNote:
         tags = res.group(1)
         tags = tags.replace('"\n', '",')
         self.tags = eval(tags)
-        res = re.search("content:\s+'''(.+?)'''", data, re.S)
+        res = re.search("content:\s+(?:'''|\")(.+?)(?:'''|\")", data, re.S)
         assert res
         self.content = res.group(1)
 

--- a/bn.py
+++ b/bn.py
@@ -271,7 +271,6 @@ class BNote:
 
     def parse(self):
         filehandle = open(self.file)
-        d = {}
         data = filehandle.read()
         res = re.search('createdAt: "(.+?)"', data)
         assert res


### PR DESCRIPTION
Hi! Thanks for sharing your code, I've started using it a while ago and it is really useful.
I've found a minor issue and I'm providing the fix in this PR.

- When creating a note with a single line on it, Boostnote encapsulates the `content` attribute with `"` instead of `'''`
- I've updated the regex to accept both formats